### PR TITLE
Use setuptools and add SOAPpy as dependency. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='python-debianbts',
@@ -11,6 +11,7 @@ setup(
     license='GPL2',
     package_dir = {'': 'src'},
     py_modules = ['debianbts'],
+    install_requires=['SOAPpy'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",


### PR DESCRIPTION
This eases installation of "debianbts" from PyPI, because tools like "easy_install" or "pip" can automatically install the required "SOAPpy" module along with "debianbts".

The drawback is that setup.py now requires the 3rd party setuptools instead of plain distutils, but setuptools should be present on any decent python installation anyway.
