### PR TITLE
test: Make sure we are using debianbts from our tree.

### DIFF
--- a/test/test_debianbts.py
+++ b/test/test_debianbts.py
@@ -18,8 +18,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+import os
+import sys
 import unittest
 
+_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+sys.path.insert(0, os.path.join(_ROOT_DIR, 'src'))
 import debianbts as bts
 
 


### PR DESCRIPTION
Calling `import debianbts` will use the version installed on the system
since 'src/' is not in `sys.path`.

Make sure it is by inserting it before importing `debianbts`.