### PR TITLE
Post-Jessie BTS updates

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: python-debianbts
 Section: python
 Priority: optional
 Maintainer: Bastian Venthur <venthur@debian.org>
-Build-Depends: debhelper (>= 9), python-support (>= 0.6), python
+Build-Depends: debhelper (>= 9), python-support (>= 0.6), python, python-mock
 Standards-Version: 3.9.3.1
 Vcs-Git: git://github.com/venthur/python-debianbts.git
 Vcs-Browser: http://github.com/venthur/python-debianbts

--- a/src/debianbts.py
+++ b/src/debianbts.py
@@ -27,11 +27,16 @@ which represents a bugreport from the BTS.
 
 
 from datetime import datetime
+import os
 import urllib
 import urlparse
 
 import SOAPpy
 
+# Support running from Debian infrastructure
+ca_path = '/etc/ssl/ca-debian'
+if os.path.isdir(ca_path):
+    os.environ['SSL_CERT_DIR'] = ca_path
 
 # Setup the soap server
 # Default values

--- a/src/debianbts.py
+++ b/src/debianbts.py
@@ -179,20 +179,28 @@ class Bugreport(object):
         return val
 
 
-def get_status(*nr):
+def get_status(*nrs):
     """Returns a list of Bugreport objects."""
-    reply = server.get_status(*nr)
     # If we called get_status with one single bug, we get a single bug,
     # if we called it with a list of bugs, we get a list,
-    # No available bugreports returns an enmpy list
+    # No available bugreports returns an empty list
     bugs = []
-    if not reply:
-        pass
-    elif type(reply[0]) == type([]):
-        for elem in reply[0]:
-            bugs.append(_parse_status(elem))
-    else:
-        bugs.append(_parse_status(reply[0]))
+    def parse(n):
+        if not n:
+            return []
+        elif type(reply[0]) == type([]):
+            return [_parse_status(elem) for elem in reply[0]]
+        else:
+            return [_parse_status(reply[0])]
+    # Process the input in batches to avoid hitting resource limits on the BTS
+    for nr in nrs:
+        if isinstance(nr, list):
+            for i in range(0, len(nr), 500):
+                reply = server.get_status(nr[i:i+500])
+                bugs.extend(parse(reply))
+        else:
+            reply = server.get_status(nr)
+            bugs.extend(parse(reply))
     return bugs
 
 

--- a/src/debianbts.py
+++ b/src/debianbts.py
@@ -35,9 +35,9 @@ import SOAPpy
 
 # Setup the soap server
 # Default values
-URL = 'http://bugs.debian.org/cgi-bin/soap.cgi'
+URL = 'https://bugs.debian.org/cgi-bin/soap.cgi'
 NS = 'Debbugs/SOAP/V1'
-BTS_URL = 'http://bugs.debian.org/'
+BTS_URL = 'https://bugs.debian.org/'
 
 
 def _get_http_proxy():

--- a/src/debianbts.py
+++ b/src/debianbts.py
@@ -43,6 +43,8 @@ if os.path.isdir(ca_path):
 URL = 'https://bugs.debian.org/cgi-bin/soap.cgi'
 NS = 'Debbugs/SOAP/V1'
 BTS_URL = 'https://bugs.debian.org/'
+# Max number of bugs to send in a single get_status request
+BATCH_SIZE = 500
 
 
 def _get_http_proxy():
@@ -195,8 +197,8 @@ def get_status(*nrs):
     # Process the input in batches to avoid hitting resource limits on the BTS
     for nr in nrs:
         if isinstance(nr, list):
-            for i in range(0, len(nr), 500):
-                reply = server.get_status(nr[i:i+500])
+            for i in range(0, len(nr), BATCH_SIZE):
+                reply = server.get_status(nr[i:i+BATCH_SIZE])
                 bugs.extend(parse(reply))
         else:
             reply = server.get_status(nr)

--- a/test/test_debianbts.py
+++ b/test/test_debianbts.py
@@ -18,7 +18,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+import math
 import unittest
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
 
 import debianbts as bts
 
@@ -83,6 +88,15 @@ class DebianBtsTestCase(unittest.TestCase):
             self.assertEqual(type(i["header"]), type(unicode()))
             self.assertTrue(i.has_key("msg_num"))
             self.assertEqual(type(i["msg_num"]), type(int()))
+
+    def testStatusBatchesLargeBugCounts(self):
+        """get_status should perform requests in batches to reduce server load."""
+        with mock.patch.object(bts.server, 'get_status') as MockStatus:
+            MockStatus.return_value = None
+            nr = bts.BATCH_SIZE + 10.0
+            calls = int(math.ceil(nr / bts.BATCH_SIZE))
+            bts.get_status([722226] * int(nr))
+            self.assertEqual(MockStatus.call_count, calls)
 
     def testComparison(self):
         self.b1.archived = True


### PR DESCRIPTION
When bugs.debian.org was upgraded to Jessie, resources limits were set
in the Apache configuration.  This means that process of get_status
requests for a large number of bugs will cause the process to get
killed, due to exceeding the resource limits.

Processing the input to get_status in batches avoids hitting the
resource limits.  This will address Debian #722226 et.al.

The BTS also automatically redirects to HTTPS URLs now, so I changed the
default URL to https to avoid the redirect.  In addition, there is code
to detect the certificates setup on Debian infrastructure, and enable
that automatically, to make it easier to use the python-debianbts package
directly rather than copying debianbts.py.