### PR TITLE
get_status: Flatten input before sending requests

### DIFF
--- a/src/debianbts.py
+++ b/src/debianbts.py
@@ -194,15 +194,16 @@ def get_status(*nrs):
             return [_parse_status(elem) for elem in reply[0]]
         else:
             return [_parse_status(reply[0])]
+    L = []
     # Process the input in batches to avoid hitting resource limits on the BTS
     for nr in nrs:
         if isinstance(nr, list):
-            for i in range(0, len(nr), BATCH_SIZE):
-                reply = server.get_status(nr[i:i+BATCH_SIZE])
-                bugs.extend(parse(reply))
+            L.extend(nr)
         else:
-            reply = server.get_status(nr)
-            bugs.extend(parse(reply))
+            L.append(nr)
+    for i in range(0, len(L), BATCH_SIZE):
+        reply = server.get_status(L[i:i+BATCH_SIZE])
+        bugs.extend(parse(reply))
     return bugs
 
 


### PR DESCRIPTION
aca7ac258a49dc5a0e268e3889eb3d2d218ad876 introduced a performance
regression (as reported in Debian bug #795198) for typical inputs, since
every bug's status would be requested individually.

Flattening the input to a single list before performing the batch
requests ensures we're not performing unnecessary requests.

Signed-off-by: James McCoy <jamessan@debian.org>