### PR TITLE
fixed parsing of base64 string in response

### DIFF
--- a/src/debianbts.py
+++ b/src/debianbts.py
@@ -28,6 +28,7 @@ Bugreport class which represents a bugreport from the BTS.
 
 from __future__ import division, unicode_literals, absolute_import, print_function
 
+import base64
 import email
 from datetime import datetime
 import os
@@ -55,7 +56,7 @@ BTS_URL = 'https://bugs.debian.org/'
 # Max number of bugs to send in a single get_status request
 BATCH_SIZE = 500
 
-soap_client = SoapClient(location=URL, namespace=NS, soap_ns='soap')
+soap_client = SoapClient(location=URL, namespace=NS, soap_ns='soap', trace=1)
 
 
 class Bugreport(object):
@@ -314,10 +315,12 @@ def _parse_status(bug_el):
     bug = Bugreport()
 
     # plain fields
-    for field in ('originator', 'subject', 'msgid', 'package', 'severity',
+    for field in ('subject', 'msgid', 'package', 'severity',
                   'owner', 'summary', 'location', 'source', 'pending',
                   'forwarded'):
         setattr(bug, field, _uc(str(bug_el(field))))
+
+    bug.originator = _parse_string_el(bug_el('originator'))
 
     bug.date = datetime.utcfromtimestamp(float(bug_el('date')))
     bug.log_modified = datetime.utcfromtimestamp(float(bug_el('log_modified')))
@@ -373,6 +376,18 @@ def _parse_bool(el):
     """parse a boolean value from a xml element"""
     value = str(el)
     return not value.strip() in ('', '0')
+
+
+def _parse_string_el(el):
+    """read a string element, maybe encoded in base64"""
+    value = str(el)
+    el_type = el.attributes().get('xsi:type')
+    if el_type and el_type.value == 'xsd:base64Binary':
+        value = base64.b64decode(value)
+        if not PY2:
+            value = value.decode('utf-8')
+    value = _uc(value)
+    return value
 
 
 """Convert string to unicode.

--- a/src/debianbts.py
+++ b/src/debianbts.py
@@ -56,7 +56,7 @@ BTS_URL = 'https://bugs.debian.org/'
 # Max number of bugs to send in a single get_status request
 BATCH_SIZE = 500
 
-soap_client = SoapClient(location=URL, namespace=NS, soap_ns='soap', trace=1)
+soap_client = SoapClient(location=URL, namespace=NS, soap_ns='soap')
 
 
 class Bugreport(object):

--- a/test/test_debianbts.py
+++ b/test/test_debianbts.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # debianbts_test.py - Unittests for debianbts.py.
 # Copyright (C) 2009  Bastian Venthur <venthur@debian.org>
@@ -273,6 +274,25 @@ class DebianBtsTestCase(unittest.TestCase):
         bug = bts.get_status(657408)[0]
         self.assertEqual(
             bug.affects, ['epiphany-browser-dev', 'libwebkit-dev'])
+
+    def test_base64_originator(self):
+        """field originator in bug status is sometimes base64-encoded"""
+        bug = bts.get_status(711111)[0]
+        if bts.PY2:
+            self.assertIsInstance(bug.originator, unicode)
+        else:
+            self.assertIsInstance(bug.originator, str)
+        self.assertTrue(bug.originator.endswith('gmail.com>'))
+        self.assertTrue('ł' in bug.originator)
+
+    def test_string_originator(self):
+        """test reading of bug status originator that is not base64-encoded"""
+        bug = bts.get_status(711112)[0]
+        if bts.PY2:
+            self.assertIsInstance(bug.originator, unicode)
+        else:
+            self.assertIsInstance(bug.originator, str)
+        self.assertTrue(bug.originator.endswith('debian.org>'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sometimes field "originator" in get_status response is encode in
base64. Pysimplesoap doesn't decode value automatically, so we must
decode by hand if xsi:type of originator element is "xsd:base64Binary".

Fixes debian bug #799528.