### PR TITLE
Fixed missing import of email package.

### DIFF
--- a/src/debianbts.py
+++ b/src/debianbts.py
@@ -30,7 +30,7 @@ Bugreport class which represents a bugreport from the BTS.
 from __future__ import division, unicode_literals, absolute_import, print_function
 
 import base64
-import email
+import email.feedparser
 from datetime import datetime
 import os
 import sys

--- a/test/test_debianbts.py
+++ b/test/test_debianbts.py
@@ -22,7 +22,7 @@
 from __future__ import division, unicode_literals, absolute_import, print_function
 
 import datetime
-import email
+import email.message
 import math
 import random
 import unittest


### PR DESCRIPTION
There was a missing import of modules email.feedparser and email.message.
Code was running ok in tests since mock imported that submodule as side
effect at import time, but this was broken:

>> import debianbts
>> debianbts.get_bug_log(400012)