### PR TITLE
Fixed string conversion of bugreport.

### DIFF
--- a/src/debianbts.py
+++ b/src/debianbts.py
@@ -158,7 +158,7 @@ class Bugreport(object):
         # self.id = None
 
     def __unicode__(self):
-        s = '\n'.join('{}: {}'.format(key, str(value))
+        s = '\n'.join('{}: {}'.format(key, value)
                        for key, value in self.__dict__.items())
         return s + '\n'
 


### PR DESCRIPTION
In python 2, if the buglog had a ascii-incompatible unicode fields the
conversion would break by calling str() on field value.

Now the conversion use string formatting on an unicode string, so the
result stays unicode and doesn't raise encode errors.

Fixes issue #20