### PR TITLE
Add backport to changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-debianbts (2.6.0~bpo8+1) jessie-backports; urgency=medium
+
+  * Rebuild for jessie-backports.
+
+ -- Pierre Rudloff <contact@rudloff.pro>  Mon, 25 Jan 2016 00:08:10 +0100
+
 python-debianbts (2.6.0) unstable; urgency=medium
 
   * Gaetano made python-debianbts thread safe by dynamically creating


### PR DESCRIPTION
Hello,

We are planning on backporting python-debianbts 2.6.0 to jessie: https://mentors.debian.net/package/python-debianbts
@sandrotosi asked me to open this PR in case you wan to add the backport to your changelog.

Regards,