### PR TITLE
Replace erroneous Unicode values

### DIFF
--- a/src/debianbts.py
+++ b/src/debianbts.py
@@ -504,7 +504,7 @@ def _parse_string_el(el):
     if el_type and el_type.value == 'xsd:base64Binary':
         value = base64.b64decode(value)
         if not PY2:
-            value = value.decode('utf-8')
+            value = value.decode('utf-8', errors='replace')
     value = _uc(value)
     return value
 


### PR DESCRIPTION
Fixes crash when encountering malformed Debian bug reports that include
non-Unicode chars such as #326971 or #144865.