### PR TITLE
Fix syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install python-debianbts
 
 ## Quickstart
 
-```python
+```pycon
 >>> import debianbts as bts
 
 >>> bts.get_bugs('package', 'python-debianbts')


### PR DESCRIPTION
* `python` lexer is for Python source code.
* `pycon` is for transcripts of Python interactive sessions.

You want the latter in README.