### PR TITLE
debianbts.get_bug_log: insert missing delimiter between header and body

### DIFF
--- a/debianbts/debianbts.py
+++ b/debianbts/debianbts.py
@@ -327,6 +327,7 @@ def get_bug_log(nr):
 
         mail_parser = email.feedparser.FeedParser()
         mail_parser.feed(buglog["header"])
+        mail_parser.feed("\n\n")
         mail_parser.feed(buglog["body"])
         buglog["message"] = mail_parser.close()
 


### PR DESCRIPTION
When feeding messages into the feedparser, properly separate head and body. Two newlines are needed: the first ends the last header line, the second represents the empty line delimiting header and body.

Without this, the first line of the body typically ends up concatenated to the last header line, and the recognized message body begins with the second line.