### PR TITLE
allow setting of soap proxy

### DIFF
--- a/debianbts/debianbts.py
+++ b/debianbts/debianbts.py
@@ -474,6 +474,14 @@ if sys.version_info.major == 3 and sys.version_info < (3, 4, 3):
         _soap_client_kwargs['cacert'] = CA_CERTS
 
 
+def set_soap_proxy(proxy_arg):
+    _soap_client_kwargs['proxy'] = proxy_arg
+
+
+def get_soap_client_kwargs():
+    return _soap_client_kwargs
+
+        
 def _build_soap_client():
     """Factory method that creates a SoapClient.
 

--- a/debianbts/debianbts.py
+++ b/debianbts/debianbts.py
@@ -481,7 +481,7 @@ def set_soap_proxy(proxy_arg):
 def get_soap_client_kwargs():
     return _soap_client_kwargs
 
-        
+
 def _build_soap_client():
     """Factory method that creates a SoapClient.
 


### PR DESCRIPTION
Add two methods to support setting of the proxy and retrieving the kwargs used to create the SoapClient, so clients can ensure proxy is populated in tests.
