### PR TITLE
fix compatibility with pysimplesoap 1.16.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ setup(
     license='MIT',
     packages=['debianbts'],
     install_requires=[
-        # we have to pin the version here, as 1.16.2 seems to be broken
-        'pysimplesoap!=1.16.2'
+        'pysimplesoap>=1.16'
     ],
     extras_require={
       'dev': [


### PR DESCRIPTION
A workaround was added for a bug fixed in pysimplesoap 1.16.2.
The workaround must not be applied for pysimplesoap >= 1.16.2

Note that workaround can be completely removed when it is intended to support only pysimplesoap >= 1.16.2