### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: python
 
 # workaround to make travis work with python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ python:
 matrix:
   allow_failures:
     - python: "nightly"
+    - python: "3.4"
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/python-debianbts

Please let me know if you need any further details.

Thank You !!