### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+python-debianbts (3.2.4) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster (oldstable):
+    + Build-Depends: Drop versioned constraint on python3.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 20 Oct 2022 00:28:53 -0000
+
 python-debianbts (3.2.3) unstable; urgency=medium
 
   * source-only upload

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: python-debianbts
 Section: python
 Priority: optional
 Maintainer: Bastian Venthur <venthur@debian.org>
-Build-Depends: debhelper-compat (= 12), dh-python, python3 (>= 3.4), python3-pysimplesoap, python3-setuptools
+Build-Depends: debhelper-compat (= 12), dh-python, python3, python3-pysimplesoap, python3-setuptools
 Standards-Version: 4.1.1.0
 Vcs-Git: https://github.com/venthur/python-debianbts.git
 Vcs-Browser: https://github.com/venthur/python-debianbts


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/python-debianbts/9f8e16a7-4d77-4007-a107-a3918f9ca682.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/9f8e16a7-4d77-4007-a107-a3918f9ca682/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/9f8e16a7-4d77-4007-a107-a3918f9ca682/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/9f8e16a7-4d77-4007-a107-a3918f9ca682/diffoscope)).
